### PR TITLE
map marker 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "placesharingplatform_ts",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.2",
         "axios": "^1.2.1",
         "next": "13.1.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-kakao-maps-sdk": "^1.1.5",
+        "react-redux": "^8.0.5",
+        "redux": "^4.2.1",
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
@@ -23,6 +26,7 @@
         "@types/styled-components": "^5.1.26",
         "eslint": "8.33.0",
         "eslint-config-next": "13.1.6",
+        "kakao.maps.d.ts": "^0.1.33",
         "typescript": "4.9.5"
       }
     },
@@ -1818,7 +1822,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.20.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -2256,6 +2259,29 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.2.tgz",
+      "integrity": "sha512-5ZAZ7hwAKWSii5T6NTPmgIBUqyVdlDs+6JjThz6J6dmHLDm6zCzv2OjHIFAi3Vvs1qjmXU0bm6eBojukYXjVMQ==",
+      "dependencies": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.2.0",
       "dev": true,
@@ -2538,7 +2564,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -2562,12 +2587,10 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.0.27",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2577,7 +2600,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.0.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -2585,7 +2608,6 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/styled-components": {
@@ -2598,6 +2620,11 @@
         "@types/react": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.50.0",
@@ -3277,7 +3304,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4435,6 +4461,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+      "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -5482,6 +5517,65 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -5502,7 +5596,6 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -5584,6 +5677,11 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -6199,6 +6297,14 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/which": {
@@ -7543,7 +7649,6 @@
     },
     "@babel/runtime": {
       "version": "7.20.13",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -7799,6 +7904,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.2.tgz",
+      "integrity": "sha512-5ZAZ7hwAKWSii5T6NTPmgIBUqyVdlDs+6JjThz6J6dmHLDm6zCzv2OjHIFAi3Vvs1qjmXU0bm6eBojukYXjVMQ==",
+      "requires": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      }
+    },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",
       "dev": true
@@ -7953,7 +8069,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -7974,12 +8089,10 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "dev": true
+      "version": "15.7.5"
     },
     "@types/react": {
       "version": "18.0.27",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -7988,14 +8101,13 @@
     },
     "@types/react-dom": {
       "version": "18.0.10",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/scheduler": {
-      "version": "0.16.2",
-      "dev": true
+      "version": "0.16.2"
     },
     "@types/styled-components": {
       "version": "5.1.26",
@@ -8007,6 +8119,11 @@
         "@types/react": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@typescript-eslint/parser": {
       "version": "5.50.0",
@@ -8438,8 +8555,7 @@
       }
     },
     "csstype": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -9215,6 +9331,11 @@
       "version": "5.2.4",
       "dev": true
     },
+    "immer": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+      "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -9838,6 +9959,40 @@
         "kakao.maps.d.ts": "^0.1.33"
       }
     },
+    "react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -9854,8 +10009,7 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "dev": true
+      "version": "0.13.11"
     },
     "regenerator-transform": {
       "version": "0.15.1",
@@ -9915,6 +10069,11 @@
           "dev": true
         }
       }
+    },
+    "reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -10288,6 +10447,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.2",
     "axios": "^1.2.1",
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-kakao-maps-sdk": "^1.1.5",
+    "react-redux": "^8.0.5",
+    "redux": "^4.2.1",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
@@ -24,6 +27,7 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
+    "kakao.maps.d.ts": "^0.1.33",
     "typescript": "4.9.5"
   }
 }

--- a/src/components/map/KaKaoMap.tsx
+++ b/src/components/map/KaKaoMap.tsx
@@ -1,7 +1,15 @@
-import React from 'react';
+import React, { SetStateAction, useEffect, useRef, useState } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
+import { useAppDispatch } from '../../store/hook';
+import { mapActions } from '../../store/map';
 import { MapContainer } from '../styled/mainPageStyled';
+import MapMarker from './MapMarker';
 const KaKaoMap = (): JSX.Element => {
+  const [map, setMap] = useState<SetStateAction<any>>();
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(mapActions.getMap(map));
+  });
   return (
     <MapContainer>
       <Map
@@ -9,8 +17,10 @@ const KaKaoMap = (): JSX.Element => {
           lat: 37.56681969769621,
           lng: 126.97865226010863,
         }}
+        onCreate={(map) => setMap(map)}
         style={{ width: '100%', height: '100%' }}
       ></Map>
+      <MapMarker />
     </MapContainer>
   );
 };

--- a/src/components/map/MapMarker.tsx
+++ b/src/components/map/MapMarker.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react';
+import { useAppSelector } from '../../store/hook';
+import { Place } from '../../pages';
+class Marker {
+  createMarker(elem: Place, map: any): void {
+    const content = document.createElement('div');
+    content.classList.add('wrap');
+    const overlay = document.createElement('div');
+    overlay.textContent = elem.placeName;
+    overlay.classList.add('custom-overlay');
+    overlay.setAttribute('id', elem.placeId);
+    const arrow = document.createElement('div');
+    arrow.classList.add('arrow');
+    arrow.setAttribute('id', elem.placeId);
+    content.appendChild(overlay);
+    content.appendChild(arrow);
+    content.addEventListener('click', (e) => this.setMapCenterPosition(e));
+    const geocoder = new kakao.maps.services.Geocoder();
+    geocoder.addressSearch(elem.address, (result: any, status: any) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
+        const overlay = new kakao.maps.CustomOverlay({
+          content,
+          map: map,
+          position: coords,
+        });
+
+        return overlay;
+      }
+    });
+  }
+  setMapCenterPosition(e: MouseEvent): void {
+    const selectedPlaceId = e.target;
+  }
+}
+const MapMarker = () => {
+  const map = useAppSelector((state) => state.map.map);
+  const marker = new Marker();
+  const placeList = useAppSelector((state) => state.placeList.placeList);
+  useEffect(() => {
+    kakao.maps.load(() => {
+      for (const key in placeList) {
+        marker.createMarker(placeList[key], map);
+      }
+    });
+  });
+  return <div></div>;
+};
+
+export default MapMarker;

--- a/src/components/map/MapMarker.tsx
+++ b/src/components/map/MapMarker.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect } from 'react';
 import { useAppSelector } from '../../store/hook';
 import { Place } from '../../pages';
-class Marker {
+
+interface MarkerInterface {
+  createMarker(elem: Place, map: any): void;
+  setMapCenterPosition(e: MouseEvent, address: string, map: any): void;
+}
+
+class Marker implements MarkerInterface {
   createMarker(elem: Place, map: any): void {
     const content = document.createElement('div');
     content.classList.add('wrap');
@@ -14,7 +20,9 @@ class Marker {
     arrow.setAttribute('id', elem.placeId);
     content.appendChild(overlay);
     content.appendChild(arrow);
-    content.addEventListener('click', (e) => this.setMapCenterPosition(e));
+    overlay.addEventListener('click', (e): void => {
+      this.setMapCenterPosition(e, elem.address, map);
+    });
     const geocoder = new kakao.maps.services.Geocoder();
     geocoder.addressSearch(elem.address, (result: any, status: any) => {
       if (status === kakao.maps.services.Status.OK) {
@@ -29,22 +37,31 @@ class Marker {
       }
     });
   }
-  setMapCenterPosition(e: MouseEvent): void {
-    const selectedPlaceId = e.target;
+  setMapCenterPosition(e: MouseEvent, address: string, map: any): void {
+    e.stopPropagation();
+    const geocoder = new kakao.maps.services.Geocoder();
+    geocoder.addressSearch(address, (result, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const coords = new kakao.maps.LatLng(+result[0].y, +result[0].x);
+        map.setLevel(4);
+        map.panTo(coords);
+      }
+    });
+    return;
   }
 }
 const MapMarker = () => {
   const map = useAppSelector((state) => state.map.map);
-  const marker = new Marker();
   const placeList = useAppSelector((state) => state.placeList.placeList);
   useEffect(() => {
+    const marker = new Marker();
     kakao.maps.load(() => {
       for (const key in placeList) {
         marker.createMarker(placeList[key], map);
       }
     });
-  });
-  return <div></div>;
+  }, [map, placeList]);
+  return <></>;
 };
 
 export default MapMarker;

--- a/src/components/styled/globalStyled.tsx
+++ b/src/components/styled/globalStyled.tsx
@@ -15,5 +15,38 @@ const GlobalStyle = createGlobalStyle`
   a{
     cursor : pointer;
   }
+  .wrap {
+    height: 100px;
+    width: 120px;
+  }
+  .custom-overlay {
+    background: #111;
+    color: #fff;
+    height: 35%;
+    border-radius: 30px;
+    padding: 5px 20px;
+    text-align: center;
+    border: 3px solid #6a9eff;
+    position: absolute;
+    top: 0px;
+    cursor: pointer;
+    line-height: 100%;
+    z-index: 10;
+  }
+  .arrow {
+    background: #111;
+    border: 3px solid #6a9eff;
+    border-bottom: none;
+    border-left: none;
+    width: 12px;
+    height: 12px;
+    position: absolute;
+    top: 28px;
+    left: 54px;
+    transform: rotate(135deg);
+    z-index: 10;
+    cursor: pointer;
+  }
+  
 `;
 export default GlobalStyle;

--- a/src/components/styled/globalStyled.tsx
+++ b/src/components/styled/globalStyled.tsx
@@ -4,6 +4,7 @@ const GlobalStyle = createGlobalStyle`
   :root{
    --color-main : #6a9eff ;
   }
+  
   * {
     box-sizing: border-box;
     padding: 0;
@@ -11,6 +12,13 @@ const GlobalStyle = createGlobalStyle`
     list-style : none;
     text-decoration : none;
     color : #111;
+  }
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-main);
+    border-radius: 10px;
   }
   a{
     cursor : pointer;
@@ -26,7 +34,7 @@ const GlobalStyle = createGlobalStyle`
     border-radius: 30px;
     padding: 5px 20px;
     text-align: center;
-    border: 3px solid #6a9eff;
+    border: 3px solid var(--color-main);
     position: absolute;
     top: 0px;
     cursor: pointer;
@@ -35,7 +43,7 @@ const GlobalStyle = createGlobalStyle`
   }
   .arrow {
     background: #111;
-    border: 3px solid #6a9eff;
+    border: 3px solid var(--color-main);
     border-bottom: none;
     border-left: none;
     width: 12px;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,13 +2,17 @@ import type { AppProps } from 'next/app';
 import { Fragment } from 'react';
 import MainHeader from '../components/layout/MainHeader';
 import GlobalStyle from '../components/styled/globalStyled';
+import { Provider } from 'react-redux';
+import store from '../store';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <Fragment>
-      <MainHeader />
-      <GlobalStyle />
-      <Component {...pageProps} />
+      <Provider store={store}>
+        <MainHeader />
+        <GlobalStyle />
+        <Component {...pageProps} />
+      </Provider>
     </Fragment>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -37,8 +37,9 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
           <Script
-            src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.kakaokey}&libraries=services,clusterer&autoload=false`}
+            type="text/javascript"
             strategy="beforeInteractive"
+            src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.kakaokey}&libraries=services&autoload=false`}
           />
         </body>
       </Html>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,12 @@
 import axios, { AxiosResponse } from 'axios';
 import React, { Fragment } from 'react';
+import { useDispatch } from 'react-redux';
 import KaKaoMap from '../components/map/KaKaoMap';
 import KeyWordSearch from '../components/search/KeyWordSearch';
 import { PlaceListWrapper } from '../components/styled/mainPageStyled';
 import AxiosService from '../service/axios.service';
-interface Place {
+import { placeListActions } from '../store/placeList';
+export interface Place {
   placeImages: string[];
   placeId: string;
   placeName: string;
@@ -21,7 +23,7 @@ interface Place {
     OFFICE: string;
   };
 }
-interface PlaceList {
+export interface PlaceList {
   [index: string]: Place;
 }
 interface Props {
@@ -32,7 +34,9 @@ interface Props {
 }
 
 const MainPage = ({ placeList }: PlaceList) => {
-  console.log(placeList);
+  const dispatch = useDispatch();
+  dispatch(placeListActions.getPlaceList(placeList));
+
   return (
     <Fragment>
       <KaKaoMap />

--- a/src/store/hook.ts
+++ b/src/store/hook.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from '../store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,17 @@
+import { configureStore } from '@reduxjs/toolkit';
+import map from './map';
+import placeList from './placeList';
+
+const store = configureStore({
+  reducer: {
+    map,
+    placeList,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export default store;

--- a/src/store/map.ts
+++ b/src/store/map.ts
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+export interface MapInitialState {
+  map: null | HTMLElement;
+}
+const mapInitialState: MapInitialState = {
+  map: null,
+};
+const mapSlice = createSlice({
+  name: 'map',
+  initialState: mapInitialState,
+  reducers: {
+    getMap(state, action) {
+      state.map = action.payload;
+    },
+  },
+});
+export const mapActions = mapSlice.actions;
+export default mapSlice.reducer;

--- a/src/store/placeList.ts
+++ b/src/store/placeList.ts
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { PlaceList } from '../pages/index';
+export interface PlaceInitialState {
+  placeList: PlaceList;
+}
+const placeListInitialState: PlaceInitialState = {
+  placeList: {},
+};
+const placeSlice = createSlice({
+  name: 'placeList',
+  initialState: placeListInitialState,
+  reducers: {
+    getPlaceList(state, action) {
+      state.placeList = action.payload;
+    },
+  },
+});
+
+export const placeListActions = placeSlice.actions;
+export default placeSlice.reducer;


### PR DESCRIPTION
### Redux Provider

- _app.tsx

### Redux store에 kakao map ref 저장

```tsx
next-dev.js?3515:20 A non-serializable value was detected in an action, in the path: `payload`. Value
```

- 직렬화할 수 없는 값을 state, action에 넣지 않아야 한다.

### useSelector 타입 지정

- 리듀서의 타입
- 사용하는 상태의 타입

### **Define Root State and Dispatch Types**

************store.ts************

```tsx
// Infer the `RootState` and `AppDispatch` types from the store itself
export type RootState = ReturnType<typeof store.getState>
// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
export type AppDispatch = typeof store.dispatch
```

**RootState** 유형과 **Dispatch** 유형을 추출하여 필요에 따라 참조할 수 있습니다

→ 이러한 **유형**은 app/store.ts와 같은 저장소 설정 파일에서 **직접 내보낸 후** 다른 파일로 직접 가져오는 것이 안전합니다

### **Define Typed Hooks**

- 미리 정의된 `useDispatch`와 `useSelector` hooks 사용

```tsx
import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
import type { RootState, AppDispatch } from '../store'

// Use throughout your app instead of plain `useDispatch` and `useSelector`
export const useAppDispatch: () => AppDispatch = useDispatch
export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
```